### PR TITLE
fix format string

### DIFF
--- a/scripts/translate
+++ b/scripts/translate
@@ -62,7 +62,7 @@ export_markdown() {
 rm -rf "./pages"
 
 for f in $(find_markdowns); do
-    printf "Exporting $f: "
+    printf "%s" "Exporting $f: "
     export_markdown "$f" && echo "success" || echo "failed"
 done
 


### PR DESCRIPTION
The error happens because `printf` is treating part of the filename (which contains a “%”) as a format specifier.

@denisidoro 